### PR TITLE
Use environment variables for configuration

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -144,7 +144,7 @@ jobs:
             Env="${{env.deployment_env}}",
             ArtifactBucketName="${{vars.S3_ARTIFACT_BUCKET_NAME}}",
             CodeArtifactBucketKey="${{env.artifact_bucket_key}}"
-            EnvVars='${{needs.build.outputs.env_vars}}'
+            EnvVars='${{toJson(needs.build.outputs.env_vars)}}'
           tags: '[{"Key": "env", "Value": "${{env.deployment_env}}"}]'
 
 #

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -109,7 +109,7 @@ jobs:
       cft_content: ${{steps.write_cft.outputs.cft_content}}
   deploy:
     name: Deploy
-    needs: build
+    needs: [init, build]
     runs-on: ubuntu-latest
     environment: ${{needs.init.outputs.deployment_env}}
     env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -143,8 +143,8 @@ jobs:
             Component="${{env.repository_name}}",
             Env="${{env.deployment_env}}",
             ArtifactBucketName="${{vars.S3_ARTIFACT_BUCKET_NAME}}",
-            CodeArtifactBucketKey="${{env.artifact_bucket_key}}"
-            EnvVars='${{toJson(needs.build.outputs.env_vars)}}'
+            CodeArtifactBucketKey="${{env.artifact_bucket_key}}",
+            EnvVars='${{needs.build.outputs.env_vars}}'
           tags: '[{"Key": "env", "Value": "${{env.deployment_env}}"}]'
 
 #

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Write env vars to output
         id: write_env_vars
         run: |
-          ENV_VARS='${{toJson(vars)}}' python src/config.py --stringify
+          ENV_VARS='${{toJson(vars)}}' python src/config.py --no-pretty
           ls -Ahl
           echo "env_vars=$(cat env.json)" | tee -a "$GITHUB_OUTPUT"
     outputs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,6 +17,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Debugging
+        run: |
+          echo ${{toJson(github)}}
+          echo ${{toJson(vars)}}
       # Because we can't derive env variables from other env variables...
       - name: Set up pipeline vars
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Write env vars to output
         id: write_env_vars
         run: |
-          ENV_VARS='${{toJson(vars)}}' python src/config --no-pretty
+          ENV_VARS='${{toJson(vars)}}' python src/config.py --no-pretty
           ls -Ahl
           echo "env_vars=$(cat env.json)" | tee -a "$GITHUB_OUTPUT"
     outputs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -144,7 +144,7 @@ jobs:
             Env="${{env.deployment_env}}",
             ArtifactBucketName="${{vars.S3_ARTIFACT_BUCKET_NAME}}",
             CodeArtifactBucketKey="${{env.artifact_bucket_key}}"
-            EnvVars="${{needs.build.outputs.env_vars}}"
+            EnvVars='${{needs.build.outputs.env_vars}}'
           tags: '[{"Key": "env", "Value": "${{env.deployment_env}}"}]'
 
 #

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Write env vars to output
         id: write_env_vars
         run: |
-          ENV_VARS='${{toJson(vars)}}' python src/config.py --no-pretty
+          ENV_VARS='${{toJson(vars)}}' python src/config.py --stringify
           ls -Ahl
           echo "env_vars=$(cat env.json)" | tee -a "$GITHUB_OUTPUT"
     outputs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -44,10 +44,6 @@ jobs:
       # Use env vars for easier repeated reference.
       artifact_filename: ${{needs.init.outputs.artifact_filename}}
     steps:
-      - name: Debugging
-        run: |
-          echo "${{toJson(github)}}"
-          echo "${{toJson(vars)}}"
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -101,8 +101,15 @@ jobs:
             cat cft.yml
             echo "EOF"
           } | tee -a "$GITHUB_OUTPUT"
+      - name: Write env vars to output
+        id: write_env_vars
+        run: |
+          ENV_VARS='${{vars}}' python src/config --no-pretty
+          ls -Ahl
+          echo "env_vars=$(cat env.json)" | tee -a "$GITHUB_OUTPUT"
     outputs:
       cft_content: ${{steps.write_cft.outputs.cft_content}}
+      env_vars: ${{steps.write_env_vars.outputs.env_vars}}
   deploy:
     name: Deploy
     needs: [init, build]
@@ -137,6 +144,7 @@ jobs:
             Env="${{env.deployment_env}}",
             ArtifactBucketName="${{vars.S3_ARTIFACT_BUCKET_NAME}}",
             CodeArtifactBucketKey="${{env.artifact_bucket_key}}"
+            EnvVars="${{needs.build.outputs.env_vars}}"
           tags: '[{"Key": "env", "Value": "${{env.deployment_env}}"}]'
 
 #

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,27 +13,41 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-    name: Build
+  init:
+    name: Initialize
     runs-on: ubuntu-latest
     steps:
-      - name: Debugging
-        run: |
-          echo ${{toJson(github)}}
-          echo ${{toJson(vars)}}
       # Because we can't derive env variables from other env variables...
       - name: Set up pipeline vars
+        id: pipeline_vars
         run: |
-          # Calculate vars in local env first.
-          rn=`echo ${{github.repository}} | cut -d/ -f2`
-          pi="${{github.repository_owner}}.$rn.${{github.run_id}}.${{github.run_attempt}}"
+          rn="${{github.event.repository.name}}"
+          pi="${{github.event.repository.owner.login}}.$rn.${{github.run_id}}.${{github.run_attempt}}"
           af="artifact-$pi.zip"
           [ "${{github.event_name}}" == "push" ] && de="prod" || de="dev"
           abk="$de/$rn/$af"
 
-          # Then export to runner env vars (because they're used in following bash script steps).
           echo "[*] Pipeline vars:"
-          printf "artifact_filename=$af\nartifact_bucket_key=$abk\ndeployment_env=$de\npipeline_id=$pi\nrepository_name=$rn\n" | tee -a "$GITHUB_ENV"
+          printf "artifact_filename=$af\nartifact_bucket_key=$abk\ndeployment_env=$de\npipeline_id=$pi\nrepository_name=$rn\n" | tee -a "$GITHUB_OUTPUT"
+    outputs:
+      artifact_filename: ${{steps.pipeline_vars.outputs.artifact_filename}}
+      artifact_bucket_key: ${{steps.pipeline_vars.outputs.artifact_bucket_key}}
+      deployment_env: ${{steps.pipeline_vars.outputs.deployment_env}}
+      repository_name: ${{steps.pipeline_vars.outputs.repository_name}}
+      pipeline_id: ${{steps.pipeline_vars.outputs.pipeline_id}}
+  build:
+    name: Build
+    needs: init
+    runs-on: ubuntu-latest
+    environment: ${{needs.init.outputs.deployment_env}}
+    env:
+      # Use env vars for easier repeated reference.
+      artifact_filename: ${{needs.init.outputs.artifact_filename}}
+    steps:
+      - name: Debugging
+        run: |
+          echo "${{toJson(github)}}"
+          echo "${{toJson(vars)}}"
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -77,12 +91,12 @@ jobs:
         with:
           aws-region: ${{vars.AWS_REGION}}
           role-to-assume: ${{vars.AWS_DEPLOY_ROLE_ARN}}
-          role-session-name: ${{env.pipeline_id}}
+          role-session-name: ${{needs.init.outputs.pipeline_id}}
       # The next two steps, for two reasons:
       # 1. CFTs can't deploy code changes using a local zipfile.
       # 2. Avoid using Github artifacts/storage quota.
       - name: Store artifact in S3
-        run: aws s3 cp "$artifact_filename" "s3://${{vars.S3_ARTIFACT_BUCKET_NAME}}/$artifact_bucket_key"
+        run: aws s3 cp "$artifact_filename" "s3://${{vars.S3_ARTIFACT_BUCKET_NAME}}/${{needs.init.outputs.artifact_bucket_key}}"
       - name: Write CFT content to output
         id: write_cft
         run: |
@@ -92,22 +106,16 @@ jobs:
             echo "EOF"
           } | tee -a "$GITHUB_OUTPUT"
     outputs:
-      artifact_bucket_key: ${{env.artifact_bucket_key}}
       cft_content: ${{steps.write_cft.outputs.cft_content}}
-      deployment_env: ${{env.deployment_env}}
-      repository_name: ${{env.repository_name}}
-      pipeline_id: ${{env.pipeline_id}}
   deploy:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
-    environment: ${{needs.build.outputs.deployment_env}}
+    environment: ${{needs.init.outputs.deployment_env}}
     env:
-      # Put these in env vars for easier reference.
-      artifact_bucket_key: ${{needs.build.outputs.artifact_bucket_key}}
-      deployment_env: ${{needs.build.outputs.deployment_env}}
-      repository_name: ${{needs.build.outputs.repository_name}}
-      pipeline_id: ${{needs.build.outputs.pipeline_id}}
+      artifact_bucket_key: ${{needs.init.outputs.artifact_bucket_key}}
+      deployment_env: ${{needs.init.outputs.deployment_env}}
+      repository_name: ${{needs.init.outputs.repository_name}}
     steps:
       # Pull directly from outputs (because of content size).
       - name: Read CFT content from previous output
@@ -121,7 +129,7 @@ jobs:
         with:
           aws-region: ${{vars.AWS_REGION}}
           role-to-assume: ${{vars.AWS_DEPLOY_ROLE_ARN}}
-          role-session-name: ${{env.pipeline_id}}
+          role-session-name: ${{needs.init.outputs.pipeline_id}}
       - name: Deploy to AWS
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -88,7 +88,7 @@ jobs:
           aws-region: ${{vars.AWS_REGION}}
           role-to-assume: ${{vars.AWS_DEPLOY_ROLE_ARN}}
           role-session-name: ${{needs.init.outputs.pipeline_id}}
-      # The next two steps, for two reasons:
+      # The next three steps, for two reasons:
       # 1. CFTs can't deploy code changes using a local zipfile.
       # 2. Avoid using Github artifacts/storage quota.
       - name: Store artifact in S3
@@ -104,7 +104,7 @@ jobs:
       - name: Write env vars to output
         id: write_env_vars
         run: |
-          ENV_VARS='${{vars}}' python src/config --no-pretty
+          ENV_VARS='${{toJson(vars)}}' python src/config --no-pretty
           ls -Ahl
           echo "env_vars=$(cat env.json)" | tee -a "$GITHUB_OUTPUT"
     outputs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 .coverage
+__pycache__/
+env.json

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -37,18 +37,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:684cba753d64978a486e8ea9645d53de0d4e3b4a3ab1495b26bd04b9541cea2d",
-                "sha256:db7bbb1c6059e99b74dcf634e497b04addcac4c527ae2b2696e47c39eccc6c50"
+                "sha256:1d854b5880e185db546b4c759fcb664bf3326275064d2b44229cc217e8be9d7e",
+                "sha256:79b93f3370ea96ce838042bc2eac0c996aee204b01e7e6452eb77abcbe697d6a"
             ],
-            "version": "==1.34.92"
+            "version": "==1.34.101"
         },
         "botocore": {
             "hashes": [
-                "sha256:4211a22a1f6c6935e70cbb84c2cd93b29f9723eaf5036d59748dd104f389a681",
-                "sha256:d1ca4886271f184445ec737cd2e752498648cca383887c5a37b2e01c8ab94039"
+                "sha256:01f3802d25558dd7945d83884bf6885e2f84e1ff27f90b5f09614966fe18c18f",
+                "sha256:f145e8b4b8fc9968f5eb695bdc2fcc8e675df7fbc3c56102dc1f5471be6baf35"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.92"
+            "version": "==1.34.101"
         },
         "certifi": {
             "hashes": [
@@ -470,61 +470,61 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:075299460948cd12722a970c7eae43d25d37989da682997687b34ae6b87c0ef0",
-                "sha256:07dfdd492d645eea1bd70fb1d6febdcf47db178b0d99161d8e4eed18e7f62fe7",
-                "sha256:0cbdf2cae14a06827bec50bd58e49249452d211d9caddd8bd80e35b53cb04631",
-                "sha256:2055c4fb9a6ff624253d432aa471a37202cd8f458c033d6d989be4499aed037b",
-                "sha256:262fffc1f6c1a26125d5d573e1ec379285a3723363f3bd9c83923c9593a2ac25",
-                "sha256:280132aada3bc2f0fac939a5771db4fbb84f245cb35b94fae4994d4c1f80dae7",
-                "sha256:2b57780b51084d5223eee7b59f0d4911c31c16ee5aa12737c7a02455829ff067",
-                "sha256:2bd7065249703cbeb6d4ce679c734bef0ee69baa7bff9724361ada04a15b7e3b",
-                "sha256:3235d7c781232e525b0761730e052388a01548bd7f67d0067a253887c6e8df46",
-                "sha256:33c020d3322662e74bc507fb11488773a96894aa82a622c35a5a28673c0c26f5",
-                "sha256:357754dcdfd811462a725e7501a9b4556388e8ecf66e79df6f4b988fa3d0b39a",
-                "sha256:39793731182c4be939b4be0cdecde074b833f6171313cf53481f869937129ed3",
-                "sha256:3c2b77f295edb9fcdb6a250f83e6481c679335ca7e6e4a955e4290350f2d22a4",
-                "sha256:41327143c5b1d715f5f98a397608f90ab9ebba606ae4e6f3389c2145410c52b1",
-                "sha256:427e1e627b0963ac02d7c8730ca6d935df10280d230508c0ba059505e9233475",
-                "sha256:432949a32c3e3f820af808db1833d6d1631664d53dd3ce487aa25d574e18ad1c",
-                "sha256:4ba01d9ba112b55bfa4b24808ec431197bb34f09f66f7cb4fd0258ff9d3711b1",
-                "sha256:4d0e206259b73af35c4ec1319fd04003776e11e859936658cb6ceffdeba0f5be",
-                "sha256:51431d0abbed3a868e967f8257c5faf283d41ec882f58413cf295a389bb22e58",
-                "sha256:565b2e82d0968c977e0b0f7cbf25fd06d78d4856289abc79694c8edcce6eb2de",
-                "sha256:6782cd6216fab5a83216cc39f13ebe30adfac2fa72688c5a4d8d180cd52e8f6a",
-                "sha256:6afd2e84e7da40fe23ca588379f815fb6dbbb1b757c883935ed11647205111cb",
-                "sha256:710c62b6e35a9a766b99b15cdc56d5aeda0914edae8bb467e9c355f75d14ee95",
-                "sha256:84921b10aeb2dd453247fd10de22907984eaf80901b578a5cf0bb1e279a587cb",
-                "sha256:85a5dbe1ba1bf38d6c63b6d2c42132d45cbee6d9f0c51b52c59aa4afba057517",
-                "sha256:9c6384cc90e37cfb60435bbbe0488444e54b98700f727f16f64d8bfda0b84656",
-                "sha256:9dd88fce54abbdbf4c42fb1fea0e498973d07816f24c0e27a1ecaf91883ce69e",
-                "sha256:a81eb64feded34f40c8986869a2f764f0fe2db58c0530d3a4afbcde50f314880",
-                "sha256:a898c11dca8f8c97b467138004a30133974aacd572818c383596f8d5b2eb04a9",
-                "sha256:a9960dd1891b2ddf13a7fe45339cd59ecee3abb6b8326d8b932d0c5da208104f",
-                "sha256:a9a7ef30a1b02547c1b23fa9a5564f03c9982fc71eb2ecb7f98c96d7a0db5cf2",
-                "sha256:ad97ec0da94b378e593ef532b980c15e377df9b9608c7c6da3506953182398af",
-                "sha256:adf032b6c105881f9d77fa17d9eebe0ad1f9bfb2ad25777811f97c5362aa07f2",
-                "sha256:bbfe6389c5522b99768a93d89aca52ef92310a96b99782973b9d11e80511f932",
-                "sha256:bd4bacd62aa2f1a1627352fe68885d6ee694bdaebb16038b6e680f2924a9b2cc",
-                "sha256:bf0b4b8d9caa8d64df838e0f8dcf68fb570c5733b726d1494b87f3da85db3a2d",
-                "sha256:c379cdd3efc0658e652a14112d51a7668f6bfca7445c5a10dee7eabecabba19d",
-                "sha256:c58536f6892559e030e6924896a44098bc1290663ea12532c78cef71d0df8493",
-                "sha256:cbe6581fcff7c8e262eb574244f81f5faaea539e712a058e6707a9d272fe5b64",
-                "sha256:ced268e82af993d7801a9db2dbc1d2322e786c5dc76295d8e89473d46c6b84d4",
-                "sha256:cf3539007202ebfe03923128fedfdd245db5860a36810136ad95a564a2fdffff",
-                "sha256:cf62d17310f34084c59c01e027259076479128d11e4661bb6c9acb38c5e19bb8",
-                "sha256:d0194d654e360b3e6cc9b774e83235bae6b9b2cac3be09040880bb0e8a88f4a1",
-                "sha256:d3d117890b6eee85887b1eed41eefe2e598ad6e40523d9f94c4c4b213258e4a4",
-                "sha256:db2de4e546f0ec4b2787d625e0b16b78e99c3e21bc1722b4977c0dddf11ca84e",
-                "sha256:e768d870801f68c74c2b669fc909839660180c366501d4cc4b87efd6b0eee375",
-                "sha256:e7c211f25777746d468d76f11719e64acb40eed410d81c26cefac641975beb88",
-                "sha256:eed462b4541c540d63ab57b3fc69e7d8c84d5957668854ee4e408b50e92ce26a",
-                "sha256:f0bfe42523893c188e9616d853c47685e1c575fe25f737adf473d0405dcfa7eb",
-                "sha256:f609ebcb0242d84b7adeee2b06c11a2ddaec5464d21888b2c8255f5fd6a98ae4",
-                "sha256:fea9d3ca80bcf17edb2c08a4704259dadac196fe5e9274067e7a20511fad1743",
-                "sha256:fed7a72d54bd52f4aeb6c6e951f363903bd7d70bc1cad64dd1f087980d309ab9"
+                "sha256:0646599e9b139988b63704d704af8e8df7fa4cbc4a1f33df69d97f36cb0a38de",
+                "sha256:0cdcbc320b14c3e5877ee79e649677cb7d89ef588852e9583e6b24c2e5072661",
+                "sha256:0d0a0f5e06881ecedfe6f3dd2f56dcb057b6dbeb3327fd32d4b12854df36bf26",
+                "sha256:1434e088b41594baa71188a17533083eabf5609e8e72f16ce8c186001e6b8c41",
+                "sha256:16db7f26000a07efcf6aea00316f6ac57e7d9a96501e990a36f40c965ec7a95d",
+                "sha256:1cc0fe9b0b3a8364093c53b0b4c0c2dd4bb23acbec4c9240b5f284095ccf7981",
+                "sha256:1fc81d5878cd6274ce971e0a3a18a8803c3fe25457165314271cf78e3aae3aa2",
+                "sha256:2ec92012fefebee89a6b9c79bc39051a6cb3891d562b9270ab10ecfdadbc0c34",
+                "sha256:39afcd3d4339329c5f58de48a52f6e4e50f6578dd6099961cf22228feb25f38f",
+                "sha256:4a7b0ceee8147444347da6a66be737c9d78f3353b0681715b668b72e79203e4a",
+                "sha256:4a9ca3f2fae0088c3c71d743d85404cec8df9be818a005ea065495bedc33da35",
+                "sha256:4bf0655ab60d754491004a5efd7f9cccefcc1081a74c9ef2da4735d6ee4a6223",
+                "sha256:4cc37def103a2725bc672f84bd939a6fe4522310503207aae4d56351644682f1",
+                "sha256:4fc84a37bfd98db31beae3c2748811a3fa72bf2007ff7902f68746d9757f3746",
+                "sha256:5037f8fcc2a95b1f0e80585bd9d1ec31068a9bcb157d9750a172836e98bc7a90",
+                "sha256:54de9ef3a9da981f7af93eafde4ede199e0846cd819eb27c88e2b712aae9708c",
+                "sha256:556cf1a7cbc8028cb60e1ff0be806be2eded2daf8129b8811c63e2b9a6c43bca",
+                "sha256:57e0204b5b745594e5bc14b9b50006da722827f0b8c776949f1135677e88d0b8",
+                "sha256:5a5740d1fb60ddf268a3811bcd353de34eb56dc24e8f52a7f05ee513b2d4f596",
+                "sha256:5c3721c2c9e4c4953a41a26c14f4cef64330392a6d2d675c8b1db3b645e31f0e",
+                "sha256:5fa567e99765fe98f4e7d7394ce623e794d7cabb170f2ca2ac5a4174437e90dd",
+                "sha256:5fd215c0c7d7aab005221608a3c2b46f58c0285a819565887ee0b718c052aa4e",
+                "sha256:6175d1a0559986c6ee3f7fccfc4a90ecd12ba0a383dcc2da30c2b9918d67d8a3",
+                "sha256:61c4bf1ba021817de12b813338c9be9f0ad5b1e781b9b340a6d29fc13e7c1b5e",
+                "sha256:6537e7c10cc47c595828b8a8be04c72144725c383c4702703ff4e42e44577312",
+                "sha256:68f962d9b72ce69ea8621f57551b2fa9c70509af757ee3b8105d4f51b92b41a7",
+                "sha256:7352b9161b33fd0b643ccd1f21f3a3908daaddf414f1c6cb9d3a2fd618bf2572",
+                "sha256:796a79f63eca8814ca3317a1ea443645c9ff0d18b188de470ed7ccd45ae79428",
+                "sha256:79afb6197e2f7f60c4824dd4b2d4c2ec5801ceb6ba9ce5d2c3080e5660d51a4f",
+                "sha256:7a588d39e0925f6a2bff87154752481273cdb1736270642aeb3635cb9b4cad07",
+                "sha256:8748731ad392d736cc9ccac03c9845b13bb07d020a33423fa5b3a36521ac6e4e",
+                "sha256:8fe7502616b67b234482c3ce276ff26f39ffe88adca2acf0261df4b8454668b4",
+                "sha256:9314d5678dcc665330df5b69c1e726a0e49b27df0461c08ca12674bcc19ef136",
+                "sha256:9735317685ba6ec7e3754798c8871c2f49aa5e687cc794a0b1d284b2389d1bd5",
+                "sha256:9981706d300c18d8b220995ad22627647be11a4276721c10911e0e9fa44c83e8",
+                "sha256:9e78295f4144f9dacfed4f92935fbe1780021247c2fabf73a819b17f0ccfff8d",
+                "sha256:b016ea6b959d3b9556cb401c55a37547135a587db0115635a443b2ce8f1c7228",
+                "sha256:b6cf3764c030e5338e7f61f95bd21147963cf6aa16e09d2f74f1fa52013c1206",
+                "sha256:beccf7b8a10b09c4ae543582c1319c6df47d78fd732f854ac68d518ee1fb97fa",
+                "sha256:c0884920835a033b78d1c73b6d3bbcda8161a900f38a488829a83982925f6c2e",
+                "sha256:c3e757949f268364b96ca894b4c342b41dc6f8f8b66c37878aacef5930db61be",
+                "sha256:ca498687ca46a62ae590253fba634a1fe9836bc56f626852fb2720f334c9e4e5",
+                "sha256:d1d0d98d95dd18fe29dc66808e1accf59f037d5716f86a501fc0256455219668",
+                "sha256:d21918e9ef11edf36764b93101e2ae8cc82aa5efdc7c5a4e9c6c35a48496d601",
+                "sha256:d7fed867ee50edf1a0b4a11e8e5d0895150e572af1cd6d315d557758bfa9c057",
+                "sha256:db66fc317a046556a96b453a58eced5024af4582a8dbdc0c23ca4dbc0d5b3146",
+                "sha256:dde0070c40ea8bb3641e811c1cfbf18e265d024deff6de52c5950677a8fb1e0f",
+                "sha256:df4e745a81c110e7446b1cc8131bf986157770fa405fe90e15e850aaf7619bc8",
+                "sha256:e2213def81a50519d7cc56ed643c9e93e0247f5bbe0d1247d15fa520814a7cd7",
+                "sha256:ef48e2707fb320c8f139424a596f5b69955a85b178f15af261bab871873bb987",
+                "sha256:f152cbf5b88aaeb836127d920dd0f5e7edff5a66f10c079157306c4343d86c19",
+                "sha256:fc0b4d8bfeabd25ea75e94632f5b6e047eef8adaed0c2161ada1e922e7f7cece"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.5.0"
+            "version": "==7.5.1"
         },
         "idna": {
             "hashes": [
@@ -599,12 +599,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6c06dc309ff46a05721e6fd48e492a775ed8165d2ecdf57f156a80c7e95bb142",
-                "sha256:f3c45d1d5eed96b01a2aea70dee6a4a366d51d38f9957768083e4fecfc77f3ef"
+                "sha256:1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233",
+                "sha256:d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.1.2"
+            "version": "==8.2.0"
         },
         "pytest-cov": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ python src/config.py
 
 <details>
 <summary>Two notes about the above step ^</summary>
+
 1. This generates an `env.json` file in the root directory of your local repo, you'll need to fill this out as needed if you want to run code using those variables locally.
 2. `env.json` is ignored by this repo, meaning that any changes you make to it, will (and should!) stay only on your local machine.
+
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ pipenv sync --dev
 python src/config.py
 ```
 
-Two notes about the above step ^:
-1. This generates an `env.json` file in the root directory of the repo, you'll need to fill this out as needed if you want to run code using those variables locally
-2. `env.json` is ignored by this repo, meaning that any changes you make to it, will stay only on your local machine.
+<details>
+<summary>Two notes about the above step ^</summary>
+1. This generates an `env.json` file in the root directory of your local repo, you'll need to fill this out as needed if you want to run code using those variables locally.
+2. `env.json` is ignored by this repo, meaning that any changes you make to it, will (and should!) stay only on your local machine.
+</details>
 
 
 Add a new dependency:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ A Twitch bot to handle/manage events from different streamers.
 
 ## Contributing
 
+All steps prefixed with `(required)` must be done to fully setup your local repository.
+
 ### Download
 
+(required) Clone the repo and enter it:
 ```bash
 git clone git@github.com:passiondynamics/bryti.git
 cd bryti/
@@ -15,15 +18,25 @@ cd bryti/
 
 ### Virtual environment
 
-Enter(/create) the virtual env:
+(required) Enter(/create) the virtual env:
 ```bash
 pipenv shell
 ```
 
-Install all dependencies listed in `Pipfile.lock`:
+(required) Install all dependencies listed in `Pipfile.lock`:
 ```bash
 pipenv sync --dev
 ```
+
+(required) Set up local environment variables:
+```bash
+python src/config.py
+```
+
+Two notes about the above step ^:
+1. This generates an `env.json` file in the root directory of the repo, you'll need to fill this out as needed if you want to run code using those variables locally
+2. `env.json` is ignored by this repo, meaning that any changes you make to it, will stay only on your local machine.
+
 
 Add a new dependency:
 ```bash

--- a/cft.yml
+++ b/cft.yml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::LanguageExtensions
 Parameters:
   Component:
     Type: String
@@ -24,6 +25,9 @@ Resources:
       Code:
         S3Bucket: !Ref ArtifactBucketName
         S3Key: !Ref CodeArtifactBucketKey
+      Environment:
+        Variables:
+          
       EphemeralStorage:
         Size: 512
       FunctionName: !Sub '${Component}-${Env}'

--- a/cft.yml
+++ b/cft.yml
@@ -30,10 +30,8 @@ Resources:
           "Fn::ForEach::EnvVarLoop":
             - EnvVarKeyPair
             - ["env=dev"]
-            - "env": Fn::Select:
-              - 1
-              - Fn::Split: ["=", "$EnvVarKeyPair"]
-              
+            - - "env"
+              - Fn::Select: [1, Fn::Split: ["=", "$EnvVarKeyPair"]]
       EphemeralStorage:
         Size: 512
       FunctionName: !Sub '${Component}-${Env}'

--- a/cft.yml
+++ b/cft.yml
@@ -16,6 +16,9 @@ Parameters:
   CodeArtifactBucketKey:
     Type: String
     Description: The key/path in the artifact bucket to the Lambda code zipfile.
+  EnvVars:
+    Type: String
+    Description: The encoded environment variable key-pairs to attach to the Lambda.
 Resources:
   LambdaFunction:
     Type: 'AWS::Lambda::Function'
@@ -27,11 +30,13 @@ Resources:
         S3Key: !Ref CodeArtifactBucketKey
       Environment:
         Variables:
-          "Fn::ForEach::EnvVarLoop":
-            - EnvVarKeyPair
-            - ["env=dev"]
-            - - "env"
-              - Fn::Select: [1, Fn::Split: ["=", "$EnvVarKeyPair"]]
+          # See https://github.com/aws-cloudformation/cfn-language-discussion/issues/55
+#          "Fn::ForEach::EnvVarLoop":
+#            - EnvVarKey
+#            - ["env"]
+#            - Name: Fn::Select: [0, Fn::Split: ["=", "$EnvVarKeyPair"]]
+#              Value: Fn::Select: [1, Fn::Split: ["=", "$EnvVarKeyPair"]]
+          ENV_VARS: !Ref EnvVars
       EphemeralStorage:
         Size: 512
       FunctionName: !Sub '${Component}-${Env}'

--- a/cft.yml
+++ b/cft.yml
@@ -27,7 +27,13 @@ Resources:
         S3Key: !Ref CodeArtifactBucketKey
       Environment:
         Variables:
-          
+          "Fn::ForEach::EnvVarLoop":
+            - EnvVarKeyPair
+            - ["env=dev"]
+            - "env": Fn::Select:
+              - 1
+              - Fn::Split: ["=", "$EnvVarKeyPair"]
+              
       EphemeralStorage:
         Size: 512
       FunctionName: !Sub '${Component}-${Env}'

--- a/src/config.py
+++ b/src/config.py
@@ -34,7 +34,7 @@ def main():
     env_vars = load_env_vars()
     if sys.argv[1:] == ["--stringify"]:
         # Double-encode compacted JSON.
-        output = json.dumps(json.dumps(env_vars, separators=(",", ":")))
+        output = json.dumps(env_vars, separators=(",", ":"))
     else:
         output = json.dumps(env_vars, indent=4)
 

--- a/src/config.py
+++ b/src/config.py
@@ -30,7 +30,7 @@ def load_env_vars():
     return {k: env_vars.get(k) for k in ENV_VAR_KEYS}
 
 
-if __name__ == "__main__":
+def main():
     env_vars = load_env_vars()
     if sys.argv[1:] == ["--no-pretty"]:
         output = json.dumps(env_vars, separators=(",", ":"))
@@ -39,3 +39,7 @@ if __name__ == "__main__":
 
     with open(ENV_VARS_FILEPATH, "w") as f:
         f.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -34,7 +34,7 @@ def main():
     env_vars = load_env_vars()
     if sys.argv[1:] == ["--stringify"]:
         # Double-encode compacted JSON.
-        output = json.dumps(env_vars, separators=(",", ":"))
+        output = json.dumps(json.dumps(env_vars, separators=(",", ":")))
     else:
         output = json.dumps(env_vars, indent=4)
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,41 @@
+import argparse
+import json
+import os
+import sys
+
+
+ENV_VAR_KEYS = []
+ENV_VARS_FILEPATH = "env.json"
+
+
+def load_env_vars():
+    """
+    Looks for environment variables in three places, in order:
+    - a packed JSON value from ENV_VARS environment variable (expected when running in a Lambda or Actions context),
+    - an `env.json` file in the root (expected when running locally),
+    - a generated default (expected when running locally for the first time).
+    and filters out only the matching keys from ENV_VAR_KEYS.
+
+    :return: environment variables to be used during execution.
+    """
+
+    env_vars = {}
+    env_vars_json = os.getenv("ENV_VARS")
+    if env_vars_json:
+        env_vars = json.loads(env_vars_json)
+    elif os.path.isfile(ENV_VARS_FILEPATH):
+        with open(ENV_VARS_FILEPATH, "r") as f:
+            env_vars = json.load(f)
+
+    return {k: env_vars.get(k) for k in ENV_VAR_KEYS}
+
+
+if __name__ == "__main__":
+    env_vars = load_env_vars()
+    if sys.argv[1:] == ["--no-pretty"]:
+        output = json.dumps(env_vars, separators=(",", ":"))
+    else:
+        output = json.dumps(env_vars, indent=4)
+
+    with open(ENV_VARS_FILEPATH, "w") as f:
+        f.write(output)

--- a/src/config.py
+++ b/src/config.py
@@ -32,9 +32,8 @@ def load_env_vars():
 
 def main():
     env_vars = load_env_vars()
-    if sys.argv[1:] == ["--stringify"]:
-        # Double-encode compacted JSON.
-        output = json.dumps(json.dumps(env_vars, separators=(",", ":")))
+    if sys.argv[1:] == ["--no-pretty"]:
+        output = json.dumps(env_vars, separators=(",", ":"))
     else:
         output = json.dumps(env_vars, indent=4)
 

--- a/src/config.py
+++ b/src/config.py
@@ -32,8 +32,9 @@ def load_env_vars():
 
 def main():
     env_vars = load_env_vars()
-    if sys.argv[1:] == ["--no-pretty"]:
-        output = json.dumps(env_vars, separators=(",", ":"))
+    if sys.argv[1:] == ["--stringify"]:
+        # Double-encode compacted JSON.
+        output = json.dumps(json.dumps(env_vars, separators=(",", ":")))
     else:
         output = json.dumps(env_vars, indent=4)
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,8 +6,11 @@ from typing import (
     Dict,
 )
 
+from src.config import load_env_vars
+
 
 logger = Logger(service="bryti")
+env_vars = load_env_vars()
 
 
 @logger.inject_lambda_context()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -60,7 +60,7 @@ class TestConfig:
         "args, expected",
         [
             ([""], '{\n    "API_KEY": "mock-value"\n}'),
-            (["", "--no-pretty"], '{"API_KEY":"mock-value"}'),
+            (["", "--stringify"], r'''"{\"API_KEY\":\"mock-value\"}"'''),
         ],
     )
     @patch("src.config.open")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -45,7 +45,8 @@ class TestConfig:
                 actual = load_env_vars()
 
                 assert actual == expected
-                mock_file.assert_called_with("env.json", "r")
+                # Not working on Github runner.
+                # mock_file.assert_called_with("env.json", "r")
 
     @pytest.mark.parametrize(
         "args, expected",
@@ -62,4 +63,5 @@ class TestConfig:
         mock_open.return_value.__enter__.return_value = mock_file
         with patch("sys.argv", args):
             main()
-            mock_file.write.assert_called_with(expected)
+            # Not working on Github runner.
+            # mock_file.write.assert_called_with(expected)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -60,7 +60,7 @@ class TestConfig:
         "args, expected",
         [
             ([""], '{\n    "API_KEY": "mock-value"\n}'),
-            (["", "--stringify"], r'''"{\"API_KEY\":\"mock-value\"}"'''),
+            (["", "--no-pretty"], '{"API_KEY":"mock-value"}'),
         ],
     )
     @patch("src.config.open")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -23,6 +23,9 @@ class TestConfig:
         ],
     )
     def test_load_env_vars_env(self, env_var_keys, env_vars_str, expected, monkeypatch):
+        """
+        Validate that `load_env_vars()` can read from the `ENV_VARS` environment variable.
+        """
         with patch("src.config.ENV_VAR_KEYS", env_var_keys):
             monkeypatch.setenv("ENV_VARS", env_vars_str)
             actual = load_env_vars()
@@ -39,16 +42,19 @@ class TestConfig:
             (["API_KEY"], '{"API_KEY": "mock-value", "BASE_URL": "mock-value-2"}', {"API_KEY": "mock-value"}),
         ],
     )
-    @patch("src.config.open")
-    def test_load_env_vars_file(self, mock_open, env_var_keys, env_json_contents, expected, monkeypatch):
-        mock_file = MagicMock()
-        mock_file.read.return_value = env_json_contents
-        mock_open.return_value.__enter__.return_value = mock_file
+    @patch("src.config.os.path.isfile")
+    def test_load_env_vars_file(self, mock_isfile, env_var_keys, env_json_contents, expected, monkeypatch):
+        """
+        Validate that `load_env_vars()` can read from the local environment file `env.json`.
+        """
+        mock_isfile.return_value = True
+        mock_open_handler = mock_open(read_data=env_json_contents)
         with patch("src.config.ENV_VAR_KEYS", env_var_keys):
-            actual = load_env_vars()
+            with patch("src.config.open", mock_open_handler):
+                actual = load_env_vars()
 
-            assert actual == expected
-            assert mock_file.read.call_count == 1
+                assert actual == expected
+                mock_open_handler.assert_called_once_with("env.json", "r")
 
     @pytest.mark.parametrize(
         "args, expected",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -41,7 +41,7 @@ class TestConfig:
     )
     def test_load_env_vars_file(self, env_var_keys, env_json_contents, expected, monkeypatch):
         with patch("src.config.ENV_VAR_KEYS", env_var_keys):
-            with patch("builtins.open", mock_open(read_data=env_json_contents)) as mock_file:
+            with patch("src.config.open", mock_open(read_data=env_json_contents)) as mock_file:
                 actual = load_env_vars()
 
                 assert actual == expected
@@ -54,7 +54,7 @@ class TestConfig:
             (["", "--no-pretty"], '{"API_KEY":"mock-value"}'),
         ],
     )
-    @patch("builtins.open")
+    @patch("src.config.open")
     @patch("src.config.load_env_vars")
     def test_main(self, mock_load_env_vars, mock_open, args, expected):
         mock_load_env_vars.return_value = {"API_KEY": "mock-value"}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -39,14 +39,16 @@ class TestConfig:
             (["API_KEY"], '{"API_KEY": "mock-value", "BASE_URL": "mock-value-2"}', {"API_KEY": "mock-value"}),
         ],
     )
-    def test_load_env_vars_file(self, env_var_keys, env_json_contents, expected, monkeypatch):
+    @patch("src.config.open")
+    def test_load_env_vars_file(self, mock_open, env_var_keys, env_json_contents, expected, monkeypatch):
+        mock_file = MagicMock()
+        mock_file.read.return_value = env_json_contents
+        mock_open.return_value.__enter__.return_value = mock_file
         with patch("src.config.ENV_VAR_KEYS", env_var_keys):
-            with patch("src.config.open", mock_open(read_data=env_json_contents)) as mock_file:
-                actual = load_env_vars()
+            actual = load_env_vars()
 
-                assert actual == expected
-                # Not working on Github runner.
-                # mock_file.assert_called_with("env.json", "r")
+            assert actual == expected
+            assert mock_file.read.call_count == 1
 
     @pytest.mark.parametrize(
         "args, expected",
@@ -63,5 +65,4 @@ class TestConfig:
         mock_open.return_value.__enter__.return_value = mock_file
         with patch("sys.argv", args):
             main()
-            # Not working on Github runner.
-            # mock_file.write.assert_called_with(expected)
+            mock_file.write.assert_called_with(expected)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,65 @@
+from unittest.mock import (
+    MagicMock,
+    mock_open,
+    patch,
+)
+import pytest
+
+from src.config import (
+    load_env_vars,
+    main,
+)
+
+
+class TestConfig:
+    @pytest.mark.parametrize(
+        "env_var_keys, env_vars_str, expected",
+        [
+            ([], '{}', {}),
+            ([], '{"API_KEY": "MOCK-VALUE"}', {}),
+            (["API_KEY"], '{}', {"API_KEY": None}),
+            (["API_KEY"], '{"API_KEY": "mock-value"}', {"API_KEY": "mock-value"}),
+            (["API_KEY"], '{"API_KEY": "mock-value", "BASE_URL": "mock-value-2"}', {"API_KEY": "mock-value"}),
+        ],
+    )
+    def test_load_env_vars_env(self, env_var_keys, env_vars_str, expected, monkeypatch):
+        with patch("src.config.ENV_VAR_KEYS", env_var_keys):
+            monkeypatch.setenv("ENV_VARS", env_vars_str)
+            actual = load_env_vars()
+
+            assert actual == expected
+
+    @pytest.mark.parametrize(
+        "env_var_keys, env_json_contents, expected",
+        [
+            ([], '{}', {}),
+            ([], '{"API_KEY": "MOCK-VALUE"}', {}),
+            (["API_KEY"], '{}', {"API_KEY": None}),
+            (["API_KEY"], '{"API_KEY": "mock-value"}', {"API_KEY": "mock-value"}),
+            (["API_KEY"], '{"API_KEY": "mock-value", "BASE_URL": "mock-value-2"}', {"API_KEY": "mock-value"}),
+        ],
+    )
+    def test_load_env_vars_file(self, env_var_keys, env_json_contents, expected, monkeypatch):
+        with patch("src.config.ENV_VAR_KEYS", env_var_keys):
+            with patch("builtins.open", mock_open(read_data=env_json_contents)) as mock_file:
+                actual = load_env_vars()
+
+                assert actual == expected
+                mock_file.assert_called_with("env.json", "r")
+
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            ([""], '{\n    "API_KEY": "mock-value"\n}'),
+            (["", "--no-pretty"], '{"API_KEY":"mock-value"}'),
+        ],
+    )
+    @patch("builtins.open")
+    @patch("src.config.load_env_vars")
+    def test_main(self, mock_load_env_vars, mock_open, args, expected):
+        mock_load_env_vars.return_value = {"API_KEY": "mock-value"}
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+        with patch("sys.argv", args):
+            main()
+            mock_file.write.assert_called_with(expected)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,7 +13,7 @@ MOCK_CONTEXT = SimpleNamespace(**{
 })
 
 
-class TestMain():
+class TestMain:
     def test_main(self):
         event = {}
         expected = {}
@@ -21,3 +21,4 @@ class TestMain():
         actual = lambda_handler(event, MOCK_CONTEXT)
 
         assert actual == {}
+


### PR DESCRIPTION
### Justification

See [cast-le-backend#20](https://github.com/passiondynamics/cast-le-backend/pull/20#discussion_r1589873895) discussion.

### Major changes

- Creates `src/config.py` script for managing/using environment variables for the project.
  - In context of running the backend normally, it pulls values from the environment variables listed in `ENV_VAR_KEYS`.
  - In context of local/pipeline setup, it generates an `env.json` file (based on same environment variables in `ENV_VAR_KEYS`).
- Pipeline:
  - Uses config script to retrieve relevant env vars to attach to Lambda.

### Minor changes

- gitignores `__pycache__/` dir and generated `env.json` from config script.
- Pipeline:
  - Moves `pipeline_vars` into separate `init` job.
  - Uses step outputs instead of `env`.
  - Adds `EnvVars` param to CFT.
- Updates dependencies.
- Adds config script instructions to README.
- Unit test config script.

### Effects

<!-- what happens differently after this merges, direct + indirect -->

---

- [x] Linked relevant ticket, or provided justification for change
- [x] Code is commented/documented well to ensure readability.
- [x] Unit testing:
  - [x] Implemented/updated.
  - [x] Run locally without any failures.
  - [x] Run in PR pipeline without any failures.
- [ ] Integration testing
  - [ ] Implemented/updated.
  - [ ] Run locally without any failures.
  - [ ] Run in PR pipeline without any failures.
- [x] Linter scan for branch has no new issues and tests introduce > 80% coverage.
- [x] Release
  - [x] Author of PR is available during deployment time to monitor release.