### PR TITLE
Attach to API Gateway and create DynamoDB table

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,8 +29,6 @@ jobs:
 
           echo "[*] Pipeline vars:"
           printf "artifact_filename=$af\nartifact_bucket_key=$abk\ndeployment_env=$de\npipeline_id=$pi\nrepository_name=$rn\n" | tee -a "$GITHUB_OUTPUT"
-      - name: Set up job summary markdown
-        run: printf "|Step|Info|\n|---|---|" | tee "$GITHUB_STEP_SUMMARY"
     outputs:
       artifact_filename: ${{steps.pipeline_vars.outputs.artifact_filename}}
       artifact_bucket_key: ${{steps.pipeline_vars.outputs.artifact_bucket_key}}
@@ -69,9 +67,13 @@ jobs:
       - name: Run linter
         run: pipenv run black --diff --check src/
       - name: Run unit tests
-        run: pipenv run pytest --cov=src --cov-fail-under=${{vars.TEST_COVERAGE_MINIMUM}} tests/unit/
-      - name: Test append to job summary
-        run: echo "|Test append to job summary|Test!|" | tee "$GITHUB_STEP_SUMMARY"
+        run: |
+          pipenv run pytest --cov=src tests/unit/
+          printf "# Unit test coverage\n\n" >> "$GITHUB_STEP_SUMMARY"
+          coverage report --skip-empty -m --format=markdown --fail-under "${{vars.TEST_COVERAGE_MINIMUM}}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+          # Stop the pipeline if under test coverage minimum.
+          tail -n 1 "$GITHUB_STEP_SUMMARY" | grep -v "Coverage failure: "
       # TODO: re-use artifact if nothing has changed.
       - name: Build artifact
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,6 +29,8 @@ jobs:
 
           echo "[*] Pipeline vars:"
           printf "artifact_filename=$af\nartifact_bucket_key=$abk\ndeployment_env=$de\npipeline_id=$pi\nrepository_name=$rn\n" | tee -a "$GITHUB_OUTPUT"
+      - name: Set up job summary markdown
+        run: printf "|Step|Info|\n|---|---|" | tee "$GITHUB_STEP_SUMMARY"
     outputs:
       artifact_filename: ${{steps.pipeline_vars.outputs.artifact_filename}}
       artifact_bucket_key: ${{steps.pipeline_vars.outputs.artifact_bucket_key}}
@@ -68,6 +70,8 @@ jobs:
         run: pipenv run black --diff --check src/
       - name: Run unit tests
         run: pipenv run pytest --cov=src --cov-fail-under=${{vars.TEST_COVERAGE_MINIMUM}} tests/unit/
+      - name: Test append to job summary
+        run: echo "|Test append to job summary|Test!|" | tee "$GITHUB_STEP_SUMMARY"
       # TODO: re-use artifact if nothing has changed.
       - name: Build artifact
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,7 +68,8 @@ jobs:
         run: pipenv run black --diff --check src/
       - name: Run unit tests
         run: |
-          pipenv run pytest --cov=src tests/unit/
+          pipenv shell
+          pytest --cov=src tests/unit/
           printf "# Unit test coverage\n\n" >> "$GITHUB_STEP_SUMMARY"
           coverage report --skip-empty -m --format=markdown --fail-under "${{vars.TEST_COVERAGE_MINIMUM}}" | tee -a "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,6 +39,7 @@ jobs:
     name: Build
     needs: init
     runs-on: ubuntu-latest
+    # TODO: remove environment
     environment: ${{needs.init.outputs.deployment_env}}
     env:
       # Use env vars for easier repeated reference.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,10 +68,9 @@ jobs:
         run: pipenv run black --diff --check src/
       - name: Run unit tests
         run: |
-          pipenv shell
-          pytest --cov=src tests/unit/
+          pipenv run pytest --cov=src tests/unit/
           printf "# Unit test coverage\n\n" >> "$GITHUB_STEP_SUMMARY"
-          coverage report --skip-empty -m --format=markdown --fail-under "${{vars.TEST_COVERAGE_MINIMUM}}" | tee -a "$GITHUB_STEP_SUMMARY"
+          pipenv run coverage report --skip-empty -m --format=markdown --fail-under "${{vars.TEST_COVERAGE_MINIMUM}}" | tee -a "$GITHUB_STEP_SUMMARY"
 
           # Stop the pipeline if under test coverage minimum.
           tail -n 1 "$GITHUB_STEP_SUMMARY" | grep -v "Coverage failure: "

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -67,6 +67,7 @@ jobs:
         run: pipenv run black --diff --check src/
       - name: Run unit tests
         run: pipenv run pytest --cov=src --cov-fail-under=${{vars.TEST_COVERAGE_MINIMUM}} tests/unit/
+      # TODO: re-use artifact if nothing has changed.
       - name: Build artifact
         run: |
           echo "[*] Downloading dependencies..."

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -143,7 +143,9 @@ jobs:
             Env="${{env.deployment_env}}",
             ArtifactBucketName="${{vars.S3_ARTIFACT_BUCKET_NAME}}",
             CodeArtifactBucketKey="${{env.artifact_bucket_key}}",
-            EnvVars='${{needs.build.outputs.env_vars}}'
+            EnvVars='${{needs.build.outputs.env_vars}}',
+            APIGatewayID="${{vars.AWS_API_GATEWAY_ID}}",
+            APIGatewayRoleARN="${{vars.AWS_API_GATEWAY_ROLE_ARN}}"
           tags: '[{"Key": "env", "Value": "${{env.deployment_env}}"}]'
 
 #

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,37 +18,37 @@
     "default": {
         "annotated-types": {
             "hashes": [
-                "sha256:0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43",
-                "sha256:563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"
+                "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53",
+                "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.6.0"
+            "version": "==0.7.0"
         },
         "aws-lambda-powertools": {
             "extras": [
                 "aws-sdk"
             ],
             "hashes": [
-                "sha256:6845995d7b0debc5b85c6d97b4336d9c536ade723d45cdc5a081477e4daa65e2",
-                "sha256:a49dacba249e6db860d59314e4620648c1691727cf43e465e8f0907f699dc5e8"
+                "sha256:3e25a51c0dc022b4ab733582ab4f39764831b31369a56424ac9f07139b5e96b3",
+                "sha256:4235f517a8429a0e4dd2f76ac3f2d0a77b4a8061fd75ca9da013e7a1b4d17699"
             ],
             "markers": "python_version >= '3.8' and python_full_version < '4.0.0'",
-            "version": "==2.37.0"
+            "version": "==2.38.1"
         },
         "boto3": {
             "hashes": [
-                "sha256:1d854b5880e185db546b4c759fcb664bf3326275064d2b44229cc217e8be9d7e",
-                "sha256:79b93f3370ea96ce838042bc2eac0c996aee204b01e7e6452eb77abcbe697d6a"
+                "sha256:8f18d212b9199dbbd9d596dd5929685b583ac938c60cceeac2e045c0c5d10323",
+                "sha256:d6a8e77db316c6e1d9a25f77c795ed1e0a8bc621f863ce26d04b2225d30f2dce"
             ],
-            "version": "==1.34.101"
+            "version": "==1.34.111"
         },
         "botocore": {
             "hashes": [
-                "sha256:01f3802d25558dd7945d83884bf6885e2f84e1ff27f90b5f09614966fe18c18f",
-                "sha256:f145e8b4b8fc9968f5eb695bdc2fcc8e675df7fbc3c56102dc1f5471be6baf35"
+                "sha256:0e0fb9b605c46393d5c7c69bd516b36058334bdc8f389e680c6efcf0727f25db",
+                "sha256:e10affb7f372d50da957260adf2753a3f153bf90abe6910e11f09d1e443b5515"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.101"
+            "version": "==1.34.111"
         },
         "certifi": {
             "hashes": [
@@ -274,12 +274,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289",
+                "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.2"
         },
         "s3transfer": {
             "hashes": [
@@ -583,11 +583,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf",
-                "sha256:17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1"
+                "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
+                "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "version": "==4.2.2"
         },
         "pluggy": {
             "hashes": [
@@ -599,12 +599,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233",
-                "sha256:d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f"
+                "sha256:5046e5b46d8e4cac199c373041f26be56fdb81eb4e67dc11d4e10811fc3408fd",
+                "sha256:faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.2.0"
+            "version": "==8.2.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -617,12 +617,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289",
+                "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.2"
         },
         "requests-mock": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pytest tests/unit
 
 Run unit tests with coverage information:
 ```bash
-pytest --cov=src --cov-fail-under=80 tests/unit
+pytest --cov-report term-missing --cov src/ --cov-fail-under "80" tests/unit/
 ```
 
 <!--

--- a/cft.yml
+++ b/cft.yml
@@ -115,7 +115,7 @@ Resources:
           Tags:
             - Key: env
               Value: !Ref Env
-      TableName: !Sub '${Component}-${Env}-state'
+      TableName: !Sub '${Component}-${Env}-state-tmp'
 
   # --- API Gateway resources (to allow external invocation) ---
   APIGatewayRoute:

--- a/cft.yml
+++ b/cft.yml
@@ -26,6 +26,7 @@ Parameters:
     Type: String
     Description: The ARN of the IAM role for API Gateway to assume for invoking the Lambda.
 Resources:
+  # --- Main Lambda function ---
   LambdaFunction:
     Type: 'AWS::Lambda::Function'
     Properties:
@@ -56,6 +57,7 @@ Resources:
           Value: !Ref Env
       Timeout: 30
 
+  # --- IAM resources (to attach to the Lambda) ---
   LambdaRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -90,6 +92,25 @@ Resources:
 #        - Key: env
 #          Value: !Ref Env
 
+  # --- DynamoDB resource (for persisting state across invocations) ---
+  DynamoDBTable:
+    Type: 'AWS::DynamoDB::GlobalTable'
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: broadcaster
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: broadcaster
+          KeyType: HASH
+      TableName: !Sub '${Component}-${Env}-state'
+      Replicas:
+        - Region: us-east-1
+          Tags:
+            - Key: env
+              Value: !Ref env
+
+  # --- API Gateway resources (to allow external invocation) ---
   APIGatewayRoute:
     Type: 'AWS::ApiGatewayV2::Route'
     Properties:
@@ -105,7 +126,6 @@ Resources:
       # IntegrationMethod: ANY
       IntegrationType: AWS_PROXY
       IntegrationUri: !GetAtt LambdaFunction.Arn
-      PayloadFormatVersion: "2.0"
+      PayloadFormatVersion: '2.0'
 
-  # TODO: Add AWS::DynamoDB::GlobalTable
 

--- a/cft.yml
+++ b/cft.yml
@@ -101,7 +101,7 @@ Resources:
     Type: 'AWS::ApiGatewayV2::Integration'
     Properties:
       ApiId: !Ref APIGatewayID
-      CredentialsArn: !Ref APIGatewayIAMRole
+      CredentialsArn: !Ref APIGatewayRoleARN
       # IntegrationMethod: ANY
       IntegrationType: AWS_PROXY
       IntegrationUri: !GetAtt LambdaFunction.Arn

--- a/cft.yml
+++ b/cft.yml
@@ -19,6 +19,12 @@ Parameters:
   EnvVars:
     Type: String
     Description: The encoded environment variable key-pairs to attach to the Lambda.
+  APIGatewayID:
+    Type: String
+    Description: The ID of the API in API Gateway.
+  APIGatewayRoleARN:
+    Type: String
+    Description: The ARN of the IAM role for API Gateway to assume for invoking the Lambda.
 Resources:
   LambdaFunction:
     Type: 'AWS::Lambda::Function'
@@ -49,6 +55,7 @@ Resources:
         - Key: env
           Value: !Ref Env
       Timeout: 30
+
   LambdaRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -63,6 +70,7 @@ Resources:
       Tags:
         - Key: env
           Value: !Ref Env
+
   LambdaPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
@@ -81,6 +89,23 @@ Resources:
 #      Tags:
 #        - Key: env
 #          Value: !Ref Env
-  # TODO: Add AWS::ApiGatewayV2::Integration
+
+  APIGatewayRoute:
+    Type: 'AWS::ApiGatewayV2::Route'
+    Properties:
+      ApiId: !Ref APIGatewayID
+      RouteKey: !Sub 'ANY /${Component}'
+      Target: !Ref APIGatewayIntegration
+
+  APIGatewayIntegration:
+    Type: 'AWS::ApiGatewayV2::Integration'
+    Properties:
+      ApiId: !Ref APIGatewayID
+      CredentialsArn: !Ref APIGatewayIAMRole
+      # IntegrationMethod: ANY
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt LambdaFunction.Arn
+      PayloadFormatVersion: "2.0"
+
   # TODO: Add AWS::DynamoDB::GlobalTable
 

--- a/cft.yml
+++ b/cft.yml
@@ -97,18 +97,25 @@ Resources:
     Type: 'AWS::DynamoDB::GlobalTable'
     Properties:
       AttributeDefinitions:
-        - AttributeName: broadcaster
+        - AttributeName: user
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: twitch-username-index
+          KeySchema:
+            - AttributeName: twitch_username
+              KeyType: HASH
+          Projection:
+            ProjectionType: KEYS_ONLY
       KeySchema:
-        - AttributeName: broadcaster
+        - AttributeName: user
           KeyType: HASH
-      TableName: !Sub '${Component}-${Env}-state'
       Replicas:
         - Region: us-east-1
           Tags:
             - Key: env
               Value: !Ref Env
+      TableName: !Sub '${Component}-${Env}-state'
 
   # --- API Gateway resources (to allow external invocation) ---
   APIGatewayRoute:
@@ -123,7 +130,6 @@ Resources:
     Properties:
       ApiId: !Ref APIGatewayID
       CredentialsArn: !Ref APIGatewayRoleARN
-      # IntegrationMethod: ANY
       IntegrationType: AWS_PROXY
       IntegrationUri: !GetAtt LambdaFunction.Arn
       PayloadFormatVersion: '2.0'

--- a/cft.yml
+++ b/cft.yml
@@ -117,7 +117,7 @@ Resources:
           Tags:
             - Key: env
               Value: !Ref Env
-      TableName: !Sub '${Component}-${Env}-state-tmp'
+      TableName: !Sub '${Component}-${Env}-state'
 
   # --- API Gateway resources (to allow external invocation) ---
   APIGatewayRoute:

--- a/cft.yml
+++ b/cft.yml
@@ -108,7 +108,7 @@ Resources:
         - Region: us-east-1
           Tags:
             - Key: env
-              Value: !Ref env
+              Value: !Ref Env
 
   # --- API Gateway resources (to allow external invocation) ---
   APIGatewayRoute:

--- a/cft.yml
+++ b/cft.yml
@@ -101,11 +101,19 @@ Resources:
           AttributeType: S
         - AttributeName: twitch_username
           AttributeType: S
+        - AttributeName: discord_username
+          AttributeType: S
       BillingMode: PAY_PER_REQUEST
       GlobalSecondaryIndexes:
         - IndexName: twitch-username-index
           KeySchema:
             - AttributeName: twitch_username
+              KeyType: HASH
+          Projection:
+            ProjectionType: KEYS_ONLY
+        - IndexName: discord-username-index
+          KeySchema:
+            - AttributeName: discord_username
               KeyType: HASH
           Projection:
             ProjectionType: KEYS_ONLY
@@ -118,6 +126,9 @@ Resources:
             - Key: env
               Value: !Ref Env
       TableName: !Sub '${Component}-${Env}-state'
+      Tags:
+        - Key: env
+          Value: !Ref Env
 
   # --- API Gateway resources (to allow external invocation) ---
   APIGatewayRoute:

--- a/cft.yml
+++ b/cft.yml
@@ -95,7 +95,7 @@ Resources:
     Properties:
       ApiId: !Ref APIGatewayID
       RouteKey: !Sub 'ANY /${Component}'
-      Target: !Ref APIGatewayIntegration
+      Target: !Sub 'integrations/${APIGatewayIntegration}'
 
   APIGatewayIntegration:
     Type: 'AWS::ApiGatewayV2::Integration'

--- a/cft.yml
+++ b/cft.yml
@@ -99,6 +99,8 @@ Resources:
       AttributeDefinitions:
         - AttributeName: user
           AttributeType: S
+        - AttributeName: twitch_username
+          AttributeType: S
       BillingMode: PAY_PER_REQUEST
       GlobalSecondaryIndexes:
         - IndexName: twitch-username-index

--- a/cft.yml
+++ b/cft.yml
@@ -126,9 +126,6 @@ Resources:
             - Key: env
               Value: !Ref Env
       TableName: !Sub '${Component}-${Env}-state'
-      Tags:
-        - Key: env
-          Value: !Ref Env
 
   # --- API Gateway resources (to allow external invocation) ---
   APIGatewayRoute:


### PR DESCRIPTION
### Justification

Need to store state across invocations + connect API to gateway.

### Changes

- Output unit test coverage in job summary.
- Provision `bryti-{env}-state` DynamoDB table
  - Generate two indices (`twitch-username-index` or `discord-username-index`) for key lookups
- Provision API gateway route + integration to Lambda.

### Effects

- Github Actions jobs should now have unit test coverage in Markdown on the summary page.
- DynamoDB and API Gateway connections are created in all envs automatically.

---

- [x] Linked relevant ticket, or provided justification for change
- [x] Code is commented/documented well to ensure readability.
- [ ] Unit testing:
  - [ ] Implemented/updated.
  - [ ] Run locally without any failures.
  - [ ] Run in PR pipeline without any failures.
- [ ] Integration testing
  - [ ] Implemented/updated.
  - [ ] Run locally without any failures.
  - [ ] Run in PR pipeline without any failures.
- [x] Linter scan for branch has no new issues and tests introduce > 80% coverage.
- [x] Release
  - [x] Author of PR is available during deployment time to monitor release.