### PR TITLE
Strip command before resolving, output relative time instead of absolute on deaths commands

### DIFF
--- a/src/common/commands.py
+++ b/src/common/commands.py
@@ -108,7 +108,9 @@ class DeathsAddCommand(AbstractDeathsCommand):
         deaths = self.state.deaths
         if deaths is None:
             self.state.deaths = DeathState(count=1, last_timestamp=self.timestamp)
-        elif (self.timestamp - deaths.last_timestamp).total_seconds() <= self.DEDUP_WINDOW_S:
+        elif (
+            self.timestamp - deaths.last_timestamp
+        ).total_seconds() <= self.DEDUP_WINDOW_S:
             return (
                 "It's been too soon since they last died! Are you sure they died again?"
             )

--- a/src/common/commands.py
+++ b/src/common/commands.py
@@ -30,6 +30,7 @@ class AbstractCommand(ABC):
         self.interfaces = interfaces
         self.state = state
         self.permission = permission
+        self.timestamp = datetime.now(tz=timezone.utc)
 
     @abstractmethod
     def execute(self) -> str:
@@ -45,9 +46,8 @@ class StatusCommand(AbstractCommand):
     """
 
     def execute(self) -> str:
-        now = datetime.now(tz=timezone.utc)
-        now_str = now.strftime(DATETIME_FMT)
-        return f"Ok at {now_str}!"
+        timestamp_str = self.timestamp.strftime(DATETIME_FMT)
+        return f"Ok at {timestamp_str}!"
 
 
 # --- deaths ---
@@ -58,8 +58,27 @@ class AbstractDeathsCommand(AbstractCommand):
         deaths = self.state.deaths
         reply = "No deaths yet!"
         if deaths is not None and deaths.count != 0:
-            timestamp_str = deaths.last_timestamp.strftime(DATETIME_FMT)
-            reply = f"Death count: {deaths.count} | Last death: {timestamp_str}"
+            time_since = self.timestamp - deaths.last_timestamp
+            s = time_since.seconds % 60
+            m = time_since.seconds // 60 % 60
+            h = time_since.seconds // 3600
+            d = time_since.days
+
+            time_since_str = ""
+            if s > 0:
+                time_since_str = f"{s}s{time_since_str}"
+            if m > 0:
+                time_since_str = f"{m}m{time_since_str}"
+            if h > 0:
+                time_since_str = f"{h}h{time_since_str}"
+            if d > 0:
+                time_since_str = f"{d}d{time_since_str}"
+            if time_since_str:
+                time_since_str += " ago"
+            else:
+                time_since_str = "just now"
+
+            reply = f"Death count: {deaths.count} | Last death: {time_since_str}"
 
         return reply
 
@@ -85,16 +104,15 @@ class DeathsAddCommand(AbstractDeathsCommand):
             return "You don't have permissions for that!"
 
         deaths = self.state.deaths
-        now = datetime.now(tz=timezone.utc)
         if deaths is None:
-            self.state.deaths = DeathState(count=1, last_timestamp=now)
-        elif (now - deaths.last_timestamp).total_seconds() <= self.DEDUP_WINDOW_S:
+            self.state.deaths = DeathState(count=1, last_timestamp=self.timestamp)
+        elif (self.timestamp - deaths.last_timestamp).total_seconds() <= self.DEDUP_WINDOW_S:
             return (
                 "It's been too soon since they last died! Are you sure they died again?"
             )
         else:
             deaths.count += 1
-            deaths.last_timestamp = now
+            deaths.last_timestamp = self.timestamp
 
         self.state = self.interfaces.state_table.update_state(self.state)
         return self._generate_reply()
@@ -111,7 +129,7 @@ class DeathsSetCommand(AbstractDeathsCommand):
 
         self.state.deaths = DeathState(
             count=deaths,
-            last_timestamp=datetime.now(tz=timezone.utc),
+            last_timestamp=self.timestamp,
         )
 
         self.state = self.interfaces.state_table.update_state(self.state)
@@ -123,6 +141,7 @@ class DeathsSetCommand(AbstractDeathsCommand):
 
 class TwitchConnectCommand(AbstractCommand):
     def execute(self) -> str:
+        # TODO: generate URL for access.
         return "Not implemented yet!"
 
 

--- a/src/common/commands.py
+++ b/src/common/commands.py
@@ -58,12 +58,14 @@ class AbstractDeathsCommand(AbstractCommand):
         deaths = self.state.deaths
         reply = "No deaths yet!"
         if deaths is not None and deaths.count != 0:
+            # Create a relative time string.
             time_since = self.timestamp - deaths.last_timestamp
             s = time_since.seconds % 60
             m = time_since.seconds // 60 % 60
             h = time_since.seconds // 3600
             d = time_since.days
 
+            # Consecutive conditions to prevent "0"s from being shown.
             time_since_str = ""
             if s > 0:
                 time_since_str = f"{s}s{time_since_str}"

--- a/src/twitch/service.py
+++ b/src/twitch/service.py
@@ -118,7 +118,7 @@ class TwitchService:
         Handle a chat message event by, if the message is a command invocation, attempting to execute it.
         """
         # Check if it matches the configured command prefix.
-        split_msg = event.message.text.lower().split()
+        split_msg = event.message.text.lower().strip().split()
         if len(split_msg) == 0 or split_msg[0] != self.command_prefix:
             return
 

--- a/tests/unit/twitch/test_service.py
+++ b/tests/unit/twitch/test_service.py
@@ -204,7 +204,7 @@ def test_handle_chat_message_not_command_prefix(mock_resolve_command, twitch_ser
 @patch("src.twitch.service.resolve_command")
 def test_handle_chat_message_nonexistant_command(mock_resolve_command, mock_api_interfaces, twitch_service):
     event = TwitchChannelChatMessage(**DEFAULT_MOCK_CHANNEL_CHAT_MESSAGE)
-    event.message.text = "!mock-command-prefix arg1 arg2 arg3"
+    event.message.text = " !mock-command-prefix arg1 arg2 arg3  "
     mock_resolve_command.return_value = (None, [])
 
     twitch_service.handle_chat_message(event)


### PR DESCRIPTION
### Justification

Fixing command invoke issue + updating `deaths` reply format

### Major changes

- `deaths` commands now reply with relative time instead of w/ an absolute timestamp (`2h3s ago` instead of `2024-01-02 17:04:08pm UTC`).

### Minor changes

- An invoke timestamp is stored when any command is created, not just in specific commands.
- Command text is stripped before resolving.

### Effects

- Command invocations should be correctly trimmed of whitespace.
- `deaths` show relative timestamp.

---

- [x] Linked relevant ticket, or provided justification for change
- [x] Code is commented/documented well to ensure readability.
- [x] Unit testing:
  - [x] Implemented/updated.
  - [x] Run locally without any failures.
  - [ ] Run in PR pipeline without any failures.
- [ ] Integration testing
  - [ ] Implemented/updated.
  - [ ] Run locally without any failures.
  - [ ] Run in PR pipeline without any failures.
- [x] Linter scan for branch has no new issues and tests introduce > 80% coverage.
- [x] Release
  - [x] Author of PR is available during deployment time to monitor release.