### PR TITLE
Split out counter-related functionality, add crime counter

### DIFF
--- a/src/common/commands.py
+++ b/src/common/commands.py
@@ -221,11 +221,11 @@ COMMAND_TREE = {
         "add": DeathsAddCommand,
         "set": DeathsSetCommand,
     },
-    # "crimes": {
-    #     None: CrimesInfoCommand,
-    #     "add": CrimesAddCommand,
-    #     "set": CrimesSetCommand,
-    # },
+    "crimes": {
+        None: CrimesInfoCommand,
+        "add": CrimesAddCommand,
+        "set": CrimesSetCommand,
+    },
     "twitch": {
         "connect": TwitchConnectCommand,
     },

--- a/src/common/state_models.py
+++ b/src/common/state_models.py
@@ -54,12 +54,41 @@ class LookupFields(BaseModel):
     github_user_id: Optional[str] = None
 
 
-class DeathState(BaseModel):
+class CounterState(BaseModel):
     count: int
     last_timestamp: ISOUTCDatetime
+
+    def time_since(self, timestamp) -> str:
+        """
+        Create a relative time string based off the given timestamp.
+        """
+
+        time_since = timestamp - self.last_timestamp
+        s = time_since.seconds % 60
+        m = time_since.seconds // 60 % 60
+        h = time_since.seconds // 3600
+        d = time_since.days
+
+        # Consecutive conditions to prevent "0"s from being shown.
+        time_since_str = ""
+        if s > 0:
+            time_since_str = f"{s}s{time_since_str}"
+        if m > 0:
+            time_since_str = f"{m}m{time_since_str}"
+        if h > 0:
+            time_since_str = f"{h}h{time_since_str}"
+        if d > 0:
+            time_since_str = f"{d}d{time_since_str}"
+        if time_since_str:
+            time_since_str += " ago"
+        else:
+            time_since_str = "just now"
+
+        return time_since_str
 
 
 class State(LookupFields):
     members: Dict[str, Permission] = {}
-    deaths: Optional[DeathState] = None
+    deaths: Optional[CounterState] = None
+    crimes: Optional[CounterState] = None
     version: int = 0

--- a/src/twitch/service.py
+++ b/src/twitch/service.py
@@ -198,6 +198,7 @@ class TwitchService:
         return can_invoke, state, permission
 
     def handle_stream_event(self, event: TwitchStreamOnline | TwitchStreamOffline):
+        # TODO: Send DeathsInfoCommand.
         pass
 
     def handle_revocation(self, body: str) -> Response:

--- a/tests/unit/common/test_commands.py
+++ b/tests/unit/common/test_commands.py
@@ -15,7 +15,7 @@ from src.common.commands import (
     resolve_command,
 )
 from src.common.state_models import (
-    DeathState,
+    CounterState,
     State,
 )
 
@@ -45,7 +45,7 @@ def test_deaths_info_command_no_deaths_state(mock_api_interfaces, mock_state):
     actual = DeathsInfoCommand(mock_api_interfaces, mock_state, Permission.EVERYBODY).execute()
     assert actual == "No deaths yet!"
 
-    mock_state.deaths = DeathState(count=0, last_timestamp="2006-01-02T15:04:05Z")
+    mock_state.deaths = CounterState(count=0, last_timestamp="2006-01-02T15:04:05Z")
     actual = DeathsInfoCommand(mock_api_interfaces, mock_state, Permission.EVERYBODY).execute()
     assert actual == "No deaths yet!"
 
@@ -64,7 +64,7 @@ def test_deaths_info_command_no_deaths_state(mock_api_interfaces, mock_state):
 @patch("src.common.commands.datetime")
 def test_deaths_info_command_with_deaths(mock_datetime, mock_api_interfaces, mock_state, datetime_args, time_since_str):
     mock_datetime.now.return_value = datetime(*datetime_args, tzinfo=timezone.utc)
-    mock_state.deaths = DeathState(count=4, last_timestamp="2006-01-02T15:04:05Z")
+    mock_state.deaths = CounterState(count=4, last_timestamp="2006-01-02T15:04:05Z")
 
     actual = DeathsInfoCommand(mock_api_interfaces, mock_state, Permission.EVERYBODY).execute()
 
@@ -83,7 +83,7 @@ def test_deaths_add_command_bad_permissions(mock_api_interfaces, mock_state):
 @patch("src.common.commands.datetime")
 def test_deaths_add_command_within_window(mock_datetime, mock_api_interfaces, mock_state, permission):
     mock_datetime.now.return_value = datetime(2006, 1, 2, 15, 4, 14, tzinfo=timezone.utc)
-    mock_state.deaths = DeathState(count=4, last_timestamp="2006-01-02T15:04:05Z")
+    mock_state.deaths = CounterState(count=4, last_timestamp="2006-01-02T15:04:05Z")
 
     actual = DeathsAddCommand(mock_api_interfaces, mock_state, permission).execute()
 
@@ -97,10 +97,10 @@ def test_deaths_add_command_within_window(mock_datetime, mock_api_interfaces, mo
 @patch("src.common.commands.datetime")
 def test_deaths_add_command(mock_datetime, mock_api_interfaces, mock_state, permission):
     mock_datetime.now.return_value = datetime(2024, 1, 2, 15, 4, 5, tzinfo=timezone.utc)
-    mock_state.deaths = DeathState(count=4, last_timestamp="2006-01-02T15:04:05Z")
+    mock_state.deaths = CounterState(count=4, last_timestamp="2006-01-02T15:04:05Z")
     updated_state = State(
         user="mock-user",
-        deaths=DeathState(
+        deaths=CounterState(
             count=5,
             last_timestamp="2024-01-02T15:04:05Z",
         ),
@@ -118,7 +118,7 @@ def test_deaths_add_command_no_deaths_state(mock_datetime, mock_api_interfaces, 
     mock_datetime.now.return_value = datetime(2006, 1, 2, 15, 4, 5, tzinfo=timezone.utc)
     updated_state = State(
         user="mock-user",
-        deaths=DeathState(
+        deaths=CounterState(
             count=1,
             last_timestamp="2006-01-02T15:04:05Z",
         ),
@@ -143,10 +143,10 @@ def test_deaths_set_command_bad_permissions(mock_api_interfaces, mock_state, per
 @patch("src.common.commands.datetime")
 def test_deaths_set_command(mock_datetime, mock_api_interfaces, mock_state):
     mock_datetime.now.return_value = datetime(2024, 1, 2, 15, 4, 5, tzinfo=timezone.utc)
-    mock_state.deaths = DeathState(count=4, last_timestamp="2006-01-02T15:04:05Z")
+    mock_state.deaths = CounterState(count=4, last_timestamp="2006-01-02T15:04:05Z")
     updated_state = State(
         user="mock-user",
-        deaths=DeathState(
+        deaths=CounterState(
             count=7,
             last_timestamp="2024-01-02T15:04:05Z",
         ),


### PR DESCRIPTION
### Justification

Adding in a `crimes` counter.

### Major changes

- `crimes` commands now work as a separate counter, pretty much exactly as the `deaths` commands do.

### Minor changes

- `AbstractCounterCommand` now houses much of the original functionality from `AbstractDeathsCommand`, to be re-used in any counter-related functionality from now on.
 
### Effects

- `crimes` command invocations now act as a separate counter.

---

- [x] Linked relevant ticket, or provided justification for change
- [x] Code is commented/documented well to ensure readability.
- [x] Unit testing:
  - [x] Implemented/updated.
  - [x] Run locally without any failures.
  - [x] Run in PR pipeline without any failures.
- [ ] Integration testing
  - [ ] Implemented/updated.
  - [ ] Run locally without any failures.
  - [ ] Run in PR pipeline without any failures.
- [x] Linter scan for branch has no new issues and tests introduce > 80% coverage.
- [x] Release
  - [x] Author of PR is available during deployment time to monitor release.